### PR TITLE
fix: Use condensed layout on index page

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,5 +1,0 @@
----
-layout: page
----
-
-{{ content }}

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 # title: Ian Lewis
 
-layout: home
+layout: page
 permalink: /
 feeds: [en, jp]
 ---


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

**Description:**

Use the condensed layout on the home/index page. This shows the navigation menu at the bottom of the page on mobile instead of the top.

**Related Issues:**

Fixes #153 

**Checklist:**

- [ ] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [CHANGELOG.md](../blob/main/CHANGELOG.md) if applicable.
