### PR TITLE
chore: Make textlint run with make lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ yaml-format: node_modules/.installed ## Format YAML files.
 #####################################################################
 
 .PHONY: lint
-lint: yamllint actionlint markdownlint ## Run all linters.
+lint: yamllint actionlint markdownlint textlint ## Run all linters.
 
 .PHONY: actionlint
 actionlint: ## Runs the actionlint linter.


### PR DESCRIPTION
**Description:**

Make `textlint` run with `make lint`

**Related Issues:**

n/A

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Update documentation if applicable.
