### PR TITLE
feat: Remove dark mode toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -187,17 +187,6 @@ vim: ft=liquid
       </nav>
       {%- endif -%}
       <p class="about-footer {{condensed_class}}">&copy; {{ "now" | date: "%Y" }} {{ site.plainwhite.name }}</p>
-      {%- if site.plainwhite.dark_mode -%}
-      <div class="about-footer {{condensed_class}}">
-        <p>Dark Mode
-          <i class="icon-moon"></i>
-          <label class="switch">
-            <input type="checkbox" class="dark-mode-toggle">
-            <span class="slider round" onclick="toggleDarkMode()"></span>
-          </label>
-        </p>
-      </div>
-      {%- endif -%}
       {% endcapture %}
       {{ footer }}
     </section>

--- a/assets/js/darkmode.js
+++ b/assets/js/darkmode.js
@@ -1,55 +1,37 @@
 // Copyright (c) 2019 Samarjeet
+// Copyright 2025 Ian Lewis
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-function toggleDarkMode() {
+function setDarkMode() {
   const DARK_CLASS = "dark";
-
   var body = document.querySelector("body");
-  if (body.classList.contains(DARK_CLASS)) {
-    setCookie("theme", "light");
-    body.classList.remove(DARK_CLASS);
-  } else {
-    setCookie("theme", "dark");
+
+  if (window.matchMedia?.("(prefers-color-scheme: dark)")?.matches) {
     body.classList.add(DARK_CLASS);
+  } else {
+    body.classList.remove(DARK_CLASS);
   }
 }
 
-function getCookie(name) {
-  var v = document.cookie.match("(^|;) ?" + name + "=([^;]*)(;|$)");
-  return v ? v[2] : null;
+// Attempt both requestAnimationFrame and DOMContentLoaded, whichever comes
+// first.
+if (window.requestAnimationFrame) {
+  window.requestAnimationFrame(setDarkMode);
 }
-function setCookie(name, value, days) {
-  var d = new Date();
-  d.setTime(d.getTime() + 24 * 60 * 60 * 1000 * days);
-  document.cookie =
-    name + "=" + value + ";path=/;SameSite=strict;expires=" + d.toGMTString();
-}
+window.addEventListener("DOMContentLoaded", setDarkMode);
 
-function deleteCookie(name) {
-  setCookie(name, "", -1);
-}
-
-const userPrefersDark =
-  window.matchMedia &&
-  window.matchMedia("(prefers-color-scheme: dark)").matches;
-var theme = getCookie("theme");
-if ((theme === null && userPrefersDark) || theme === "dark") {
-  var checkDarkDone = false;
-  function checkDark() {
-    if (!checkDarkDone) {
-      toggleDarkMode();
-    }
-    checkDarkDone = true;
-  }
-
-  function toggleSwitch() {
-    document
-      .querySelectorAll(".dark-mode-toggle")
-      .forEach((ti) => (ti.checked = true));
-  }
-
-  // Attempt both requestAnimationFrame and DOMContentLoaded, whichever comes first.
-  if (window.requestAnimationFrame) window.requestAnimationFrame(checkDark);
-  window.addEventListener("DOMContentLoaded", checkDark);
-
-  window.addEventListener("DOMContentLoaded", toggleSwitch);
-}
+// Watch for changes to the preferred color scheme.
+window
+  .matchMedia("(prefers-color-scheme: dark)")
+  .addEventListener("change", setDarkMode);


### PR DESCRIPTION
**Description:**

Remove dark mode toggle since it can't be set back to being automatic. Instead rely fully on user's device preference.

**Related Issues:**

Fixes #229 

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Update documentation if applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dark mode now automatically adapts to your system’s color scheme, providing a seamless experience that adjusts in real time.
  
- **Refactor**
  - Removed the manual dark mode toggle from the footer for a cleaner and more streamlined interface.
  - Simplified dark mode functionality by eliminating cookie management and focusing on user preferences directly through system settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->