### PR TITLE
fix: Use font-display: auto

### DIFF
--- a/_sass/ext/_fonts_google_com.scss
+++ b/_sass/ext/_fonts_google_com.scss
@@ -20,7 +20,7 @@ limitations under the License.
 
 /* merriweather-300 - cyrillic_cyrillic-ext_latin_latin-ext */
 @font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Merriweather;
   font-style: normal;
   font-weight: 300;
@@ -30,7 +30,7 @@ limitations under the License.
 
 /* merriweather-300italic - cyrillic_cyrillic-ext_latin_latin-ext */
 @font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Merriweather;
   font-style: italic;
   font-weight: 300;
@@ -40,7 +40,7 @@ limitations under the License.
 
 /* raleway-regular - cyrillic_cyrillic-ext_latin_latin-ext */
 @font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Raleway;
   font-style: normal;
   font-weight: 400;
@@ -50,7 +50,7 @@ limitations under the License.
 
 /* raleway-italic - cyrillic_cyrillic-ext_latin_latin-ext */
 @font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Raleway;
   font-style: italic;
   font-weight: 400;
@@ -60,7 +60,7 @@ limitations under the License.
 
 /* raleway-700 - cyrillic_cyrillic-ext_latin_latin-ext */
 @font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Raleway;
   font-style: normal;
   font-weight: 700;
@@ -70,7 +70,7 @@ limitations under the License.
 
 /* raleway-700italic - cyrillic_cyrillic-ext_latin_latin-ext */
 @font-face {
-  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Raleway;
   font-style: italic;
   font-weight: 700;


### PR DESCRIPTION
**Description:**

Use `font-display: auto` so that font rendering isn't janky.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Update documentation if applicable.
