### PR TITLE
feat: Use contextual word breaks

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -25,3 +25,9 @@ blockquote {
 .dark blockquote {
   background: #00080a;
 }
+
+// Word wrap Japanese text using contextual analysis.
+// See https://developers-jp.googleblog.com/2023/09/budoux-adobe.html
+.post-container {
+  word-break: auto-phrase;
+}


### PR DESCRIPTION
**Description:**

Use contextual word breaks with the `word-break: auto-phrase` CSS directive.

**Related Issues:**

Fixes #304 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Update documentation if applicable.
