### PR TITLE
fix: Add site title to feed titles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,20 @@ plugins:
   - jekyll-seo-tag
   - jekyll-paginate-v2
 
+blogs:
+  en:
+    title: English Blog
+    url: /en
+    lang: en
+  jp:
+    title: 日本語ブログ
+    url: /jp
+    lang: ja
+  til:
+    title: Today I Learned
+    url: /til
+    lang: en
+
 # Theme
 plainwhite:
   name: Ian Lewis

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,7 +14,7 @@
 {%- assign icon_image_64x64 = site.plainwhite.favicon.default_64x64 -%}
 {%- assign icon_image_96x96 = site.plainwhite.favicon.default_96x96 -%}
 
-{% if today >= valentines_start and today <= valentines_end -%}
+{%- if today >= valentines_start and today <= valentines_end -%}
   {%- if site.plainwhite.favicon.valentines_day_16x16 -%}
     {%- assign icon_image_16x16 = site.plainwhite.favicon.valentines_day_16x16 -%}
   {%- endif -%}
@@ -27,7 +27,7 @@
   {%- if site.plainwhite.favicon.valentines_day_96x96 -%}
     {%- assign icon_image_96x96 = site.plainwhite.favicon.valentines_day_96x96 -%}
   {%- endif -%}
-{% elsif today >= xmas_start and today <= xmas_end %}
+{%- elsif today >= xmas_start and today <= xmas_end -%}
   {%- if site.plainwhite.favicon.xmas_16x16 -%}
     {%- assign icon_image_16x16 = site.plainwhite.favicon.xmas_16x16 -%}
   {%- endif -%}
@@ -42,30 +42,45 @@
   {%- endif -%}
 {%- endif -%}
 
-{%- if icon_image_16x16 %}
+{%- if icon_image_16x16 -%}
   <link rel="icon" type="image/png" href="{{ site.baseurl }}/{{ icon_image_16x16 }}" sizes="16x16">
-{%- endif %}
-{%- if icon_image_32x32 %}
+{%- endif -%}
+{%- if icon_image_32x32 -%}
   <link rel="icon" type="image/png" href="{{ site.baseurl }}/{{ icon_image_32x32 }}" sizes="32x32">
-{%- endif %}
-{%- if icon_image_64x64 %}
+{%- endif -%}
+{%- if icon_image_64x64 -%}
   <link rel="icon" type="image/png" href="{{ site.baseurl }}/{{ icon_image_64x64 }}" sizes="64x64">
-{%- endif %}
-{%- if icon_image_96x96 %}
+{%- endif -%}
+{%- if icon_image_96x96 -%}
   <link rel="icon" type="image/png" href="{{ site.baseurl }}/{{ icon_image_96x96 }}" sizes="96x96">
-{%- endif %}
+{%- endif -%}
 <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
 {%- seo -%}
-{%- if page.feeds contains 'en' %}
-  <link rel="alternate" type="application/rss+xml" title="English Blog" href="/en/feed.xml">
-{%- endif %}
-{%- if page.feeds contains 'jp' %}
-  <link rel="alternate" type="application/rss+xml" title="日本語ブログ" href="/jp/feed.xml">
-{%- endif %}
-{%- if page.feeds contains 'til' %}
-  <link rel="alternate" type="application/rss+xml" title="Today I Learned" href="/til/feed.xml">
-{%- endif %}
-{%- if site.plainwhite.dark_mode %}
+{%- if page.feeds contains 'en' -%}
+  <link
+    rel="alternate"
+    type="application/rss+xml"
+    title="{{ site.title }} | {{ site.blogs.en.title }}"
+    href="/en/feed.xml"
+  >
+{%- endif -%}
+{%- if page.feeds contains 'jp' -%}
+  <link
+    rel="alternate"
+    type="application/rss+xml"
+    title="{{ site.title }} | {{ site.blogs.jp.title }}"
+    href="/jp/feed.xml"
+  >
+{%- endif -%}
+{%- if page.feeds contains 'til' -%}
+  <link
+    rel="alternate"
+    type="application/rss+xml"
+    title="{{ site.title }} | {{ site.blogs.til.title }}"
+    href="/til/feed.xml"
+  >
+{%- endif -%}
+{%- if site.plainwhite.dark_mode -%}
   <script type="text/javascript" src="{{ "/assets/js/darkmode.js" | relative_url }}"></script>
 {%- endif -%}
 {% comment %}

--- a/en/feed.xml
+++ b/en/feed.xml
@@ -4,26 +4,25 @@ layout: null
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
 <channel>
- <title>English Blog</title>
- <description>{{ site.description | xml_escape }}</description>
- <link>{{ site.url }}/en/</link>
- <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
- <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
- <ttl>1800</ttl>
+  <title>{{ site.title }} | {{ site.blogs.en.title }}</title>
+  <description>{{ site.description | xml_escape }}</description>
+  <link>{{ site.url }}/en/</link>
+  <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+  <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+  <ttl>1800</ttl>
 
- {% for post in site.categories.en %}
- <item>
-  <title>{{ post.title | xml_escape }}</title>
-  {% if post.excerpt %}
-  <description>{{ post.excerpt | xml_escape }}</description>
-  {% else %}
-  <description>{{ post.content | xml_escape }}</description>
-  {% endif %}
-  <link>{{ site.url }}{{ post.url }}</link>
-  <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
-  <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
- </item>
- {% endfor %}
-
+  {% for post in site.categories.en %}
+  <item>
+    <title>{{ post.title | xml_escape }}</title>
+    {% if post.excerpt %}
+    <description>{{ post.excerpt | xml_escape }}</description>
+    {% else %}
+    <description>{{ post.content | xml_escape }}</description>
+    {% endif %}
+    <link>{{ site.url }}{{ post.url }}</link>
+    <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+    <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+  </item>
+  {% endfor %}
 </channel>
 </rss>

--- a/jp/feed.xml
+++ b/jp/feed.xml
@@ -4,27 +4,26 @@ layout: null
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
 <channel>
- <title>日本語ブログ</title>
- <description>{{ site.description | xml_escape }}</description>
- <link>{{ site.url }}/jp/</link>
- <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
- <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
- <ttl>1800</ttl>
+  <title>{{ site.title }} | {{ site.blogs.jp.title }}</title>
+  <description>{{ site.description | xml_escape }}</description>
+  <link>{{ site.url }}/jp/</link>
+  <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+  <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+  <ttl>1800</ttl>
 
- {% for post in site.categories.jp %}
- <item>
-  <title>{{ post.title | xml_escape }}</title>
-  {% if post.excerpt %}
-  <description>{{ post.excerpt | xml_escape }}</description>
-  {% else %}
-  <description>{{ post.content | xml_escape }}</description>
-  {% endif %}
-  <description>{{ post.description | xml_escape }}</description>
-  <link>{{ site.url }}{{ post.url }}</link>
-  <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
-  <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
- </item>
- {% endfor %}
-
+  {% for post in site.categories.jp %}
+  <item>
+    <title>{{ post.title | xml_escape }}</title>
+    {% if post.excerpt %}
+    <description>{{ post.excerpt | xml_escape }}</description>
+    {% else %}
+    <description>{{ post.content | xml_escape }}</description>
+    {% endif %}
+    <description>{{ post.description | xml_escape }}</description>
+    <link>{{ site.url }}{{ post.url }}</link>
+    <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+    <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+  </item>
+  {% endfor %}
 </channel>
 </rss>

--- a/til/feed.xml
+++ b/til/feed.xml
@@ -4,26 +4,25 @@ layout: null
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
 <channel>
- <title>Today I Learned</title>
- <description>{{ site.description | xml_escape }}</description>
- <link>{{ site.url }}/til/</link>
- <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
- <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
- <ttl>1800</ttl>
+  <title>{{ site.title }} | {{ site.blogs.til.title }}</title>
+  <description>{{ site.description | xml_escape }}</description>
+  <link>{{ site.url }}/til/</link>
+  <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+  <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
+  <ttl>1800</ttl>
 
- {% for post in site.categories.til %}
- <item>
-  <title>{{ post.title | xml_escape }}</title>
-  {% if post.excerpt %}
-  <description>{{ post.excerpt | xml_escape }}</description>
-  {% else %}
-  <description>{{ post.content | xml_escape }}</description>
-  {% endif %}
-  <link>{{ site.url }}{{ post.url }}</link>
-  <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
-  <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
- </item>
- {% endfor %}
-
+  {% for post in site.categories.til %}
+  <item>
+    <title>{{ post.title | xml_escape }}</title>
+    {% if post.excerpt %}
+    <description>{{ post.excerpt | xml_escape }}</description>
+    {% else %}
+    <description>{{ post.content | xml_escape }}</description>
+    {% endif %}
+    <link>{{ site.url }}{{ post.url }}</link>
+    <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+    <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
+  </item>
+  {% endfor %}
 </channel>
 </rss>


### PR DESCRIPTION
**Description:**

Adds the site title to feed titles so it's not just "English Blog" or "日本語ブログ"

**Related Issues:**

Fixes #318 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Update documentation if applicable.
