### PR TITLE
feat: Use Montserrat and Noto fonts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -54,6 +54,15 @@
 {%- if icon_image_96x96 -%}
   <link rel="icon" type="image/png" href="{{ site.baseurl }}/{{ icon_image_96x96 }}" sizes="96x96">
 {%- endif -%}
+
+<!-- FIXME: self-host fonts -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link
+  href="https://fonts.googleapis.com/css2?family=M+PLUS+1+Code:wght@100..700&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Noto+Sans+JP:wght@100..900&family=Noto+Sans+Mono:wght@100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Noto+Serif+JP:wght@200..900&family=Noto+Serif:ital,wght@0,100..900;1,100..900&display=swap"
+  rel="stylesheet"
+>
+
 <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
 {%- seo -%}
 {%- if page.feeds contains 'en' -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -10,7 +10,7 @@ layout: default
   {% endif %}
 >
   <a class="post-link" href="{{ page.url | relative_url }}">
-    <h2 class="post-title">{{ page.title | escape }}</h2>
+    <h1 class="post-title">{{ page.title | escape }}</h1>
   </a>
   <div class="post-meta">
     <div class="post-date"><i class="icon-calendar"></i>{{ page.date | date: date_format }}</div>

--- a/_layouts/post_list.html
+++ b/_layouts/post_list.html
@@ -56,9 +56,9 @@ layout: default
             {%- comment -%}
               TODO(#315): Truncating text can cut off html entities
             {%- endcomment -%}
-            {{ post.content | strip_html | truncate: 150 }}
+            {{ post.content | strip_html | truncate: 500 }}
           {% else %}
-            {{ post.content | strip_html | truncatewords: 35 }}
+            {{ post.content | strip_html | truncatewords: 100 }}
           {% endif %}
         </div>
       </li>

--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -8,10 +8,10 @@
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
  * the Software, and to permit persons to whom the Software is furnished to do so,
  * subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
  * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
@@ -21,6 +21,9 @@
  */
 
 @use "ext/solarized-light";
+
+// monospace-font is used for code blocks and inline code.
+$monospace-font: "Noto Sans Mono", "M PLUS 1 Code", monospace;
 
 .highlight {
   background-color: #f4f4f4;
@@ -32,7 +35,7 @@ div.highlight {
 
 pre.highlight,
 code {
-  font-family: Consolas, Menlo, monospace;
+  font-family: $monospace-font;
   line-height: 1.4em;
   tab-size: 4;
 }

--- a/_sass/dark.scss
+++ b/_sass/dark.scss
@@ -74,7 +74,7 @@
 
   pre.highlight-dark,
   code {
-    font-family: Consolas, Menlo, monospace;
+    font-family: "M PLUS 1 Code", monospace;
     line-height: 1.4em;
     tab-size: 4;
     color: seagreen;

--- a/_sass/plain.scss
+++ b/_sass/plain.scss
@@ -26,6 +26,26 @@
 @use "ext/normalize";
 @use "syntax";
 
+// This is the main font pairing.
+$primary-font-family: "Montserrat", "Noto Sans JP", sans-serif;
+$secondary-font-family: "Noto Sans", "Noto Sans JP", sans-serif;
+
+@mixin primary-font-normal {
+  font-family: $primary-font-family;
+  font-weight: 400;
+}
+
+@mixin primary-font-title {
+  font-family: $primary-font-family;
+  font-weight: 800;
+}
+
+@mixin secondary-font-normal {
+  font-family: $secondary-font-family;
+  font-weight: 400;
+}
+
+// Link color is the color of links in posts.
 $link-color: #0a59b0;
 
 // small-mobile-width is the max width of small mobile devices. Small mobile
@@ -52,12 +72,22 @@ $left-width: 280px;
 }
 
 body {
-  font-family: Raleway, sans-serif;
+  @include primary-font-normal;
+
   font-size: 16px;
   line-height: 1.2em;
   margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  @include primary-font-title;
 }
 
 img,
@@ -103,8 +133,9 @@ h2 {
 }
 
 .post {
-  font-family: Merriweather, sans-serif;
-  font-weight: 300;
+  @include secondary-font-normal;
+
+  // font-weight: 300;
   color: #222;
   line-height: 1.9em;
 
@@ -121,15 +152,6 @@ h2 {
       border-bottom: 0.5px solid $link-color;
     }
   }
-
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6 {
-    font-family: Raleway, sans-serif;
-  }
 }
 
 .navigation {
@@ -144,8 +166,9 @@ h2 {
      * specificity than `.post a` */
     /* stylelint-disable-next-line no-descending-specificity */
     a {
+      @include secondary-font-normal;
+
       display: block;
-      font-family: Merriweather, serif;
       text-align: center;
       padding: 1rem 0;
       text-decoration: none;
@@ -230,6 +253,8 @@ main {
     }
 
     .tagline {
+      @include primary-font-title;
+
       text-align: center;
       font-size: 22px;
       margin-top: 0;
@@ -270,6 +295,7 @@ body:not(.dark) main img.align-center:not(.dark) {
 
 #title {
   a {
+    font-size: 1.4em;
     text-decoration: none;
   }
 }
@@ -300,6 +326,8 @@ body:not(.dark) main img.align-center:not(.dark) {
 }
 
 .post-date {
+  @include primary-font-title;
+
   margin-right: 10px;
   color: #555;
   min-width: 150px;
@@ -327,7 +355,6 @@ body:not(.dark) main img.align-center:not(.dark) {
 
 .post-title {
   line-height: 1.2em;
-  font-size: 28px;
   margin-bottom: 10px;
 }
 
@@ -371,8 +398,9 @@ table {
   }
 
   th {
+    @include primary-font-title;
+
     background-color: #eee;
-    font-family: Raleway, sans-serif;
   }
 }
 


### PR DESCRIPTION
**Description:**

Update fonts to use Montserrat and Noto.

- Montserrat: English headers and titles.
- Noto Sans: for regular English text
- Noto Sans Japanese: for regular Japanese text, headers, and titles.
- Noto Sans Mono: for code blocks

**Related Issues:**

Fixes #314

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Update documentation if applicable.
