### PR TITLE
perf: Use font-display: swap

### DIFF
--- a/_sass/ext/_fonts_google_com.scss
+++ b/_sass/ext/_fonts_google_com.scss
@@ -22,7 +22,7 @@
 
 /* montserrat-regular - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Montserrat;
   font-style: normal;
   font-weight: 400;
@@ -31,7 +31,7 @@
 
 /* montserrat-italic - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Montserrat;
   font-style: italic;
   font-weight: 400;
@@ -40,7 +40,7 @@
 
 /* montserrat-700 - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Montserrat;
   font-style: normal;
   font-weight: 700;
@@ -49,7 +49,7 @@
 
 /* montserrat-700italic - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Montserrat;
   font-style: italic;
   font-weight: 700;
@@ -58,7 +58,7 @@
 
 /* montserrat-800 - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Montserrat;
   font-style: normal;
   font-weight: 800;
@@ -67,7 +67,7 @@
 
 /* montserrat-800italic - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Montserrat;
   font-style: italic;
   font-weight: 800;
@@ -76,7 +76,7 @@
 
 /* montserrat-900 - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Montserrat;
   font-style: normal;
   font-weight: 900;
@@ -85,7 +85,7 @@
 
 /* montserrat-900italic - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: Montserrat;
   font-style: italic;
   font-weight: 900;
@@ -100,7 +100,7 @@
 
 /* noto-sans-regular - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "Noto Sans";
   font-style: normal;
   font-weight: 400;
@@ -109,7 +109,7 @@
 
 /* noto-sans-italic - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "Noto Sans";
   font-style: italic;
   font-weight: 400;
@@ -118,7 +118,7 @@
 
 /* noto-sans-700 - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "Noto Sans";
   font-style: normal;
   font-weight: 700;
@@ -127,7 +127,7 @@
 
 /* noto-sans-700italic - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "Noto Sans";
   font-style: italic;
   font-weight: 700;
@@ -142,7 +142,7 @@
 
 /* noto-sans-jp-regular - japanese_latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "Noto Sans JP";
   font-style: normal;
   font-weight: 400;
@@ -152,7 +152,7 @@
 
 /* noto-sans-jp-700 - japanese_latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "Noto Sans JP";
   font-style: normal;
   font-weight: 700;
@@ -161,7 +161,7 @@
 
 /* noto-sans-jp-800 - japanese_latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "Noto Sans JP";
   font-style: normal;
   font-weight: 800;
@@ -170,7 +170,7 @@
 
 /* noto-sans-jp-900 - japanese_latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "Noto Sans JP";
   font-style: normal;
   font-weight: 900;
@@ -185,7 +185,7 @@
 
 /* noto-sans-mono-regular - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "Noto Sans Mono";
   font-style: normal;
   font-weight: 400;
@@ -194,7 +194,7 @@
 
 /* noto-sans-mono-700 - latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "Noto Sans Mono";
   font-style: normal;
   font-weight: 700;
@@ -209,7 +209,7 @@
 
 /* m-plus-1-code-regular - japanese_latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "M PLUS 1 Code";
   font-style: normal;
   font-weight: 400;
@@ -219,7 +219,7 @@
 
 /* m-plus-1-code-700 - japanese_latin */
 @font-face {
-  font-display: auto; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
+  font-display: swap; /* Check https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display for other options. */
   font-family: "M PLUS 1 Code";
   font-style: normal;
   font-weight: 700;


### PR DESCRIPTION
**Description:**

Use `font-display: swap` so that the website visually loads faster.

**Related Issues:**

Fixes #335 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Update documentation if applicable.
