### PR TITLE
docs: add note on conventional commits to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,7 @@ not be installed manually. These dependencies include:
 - GitHub Actions workflow enforces all linting rules
 - The site supports both light and dark themes
 - Social media links include Bluesky, Mastodon, GitHub, LinkedIn
+- All commits should follow the Conventional Commits specification following the
+  `@commitlint/config-conventional` `commitlint` preset. This includes the
+  following types: `build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`,
+  `refactor`, `revert`, `style`, and `test`.


### PR DESCRIPTION
**Description:**

Adds a note to `AGENTS.md` to instruct AI agents to use conventional commits. This should be picked up by the GitHub Copilot agent.

**Related Issues:**

Fixes #436 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Update documentation if applicable.
