### PR TITLE
chore(deps): set minimumReleaseAge

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -35,6 +35,11 @@
   },
   osvVulnerabilityAlerts: true,
 
+  // Apply a dependency cooldown of 14 days. This helps to avoid issues with
+  // compromised releases.
+  // https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
+  minimumReleaseAge: "14 days",
+
   // Enable the lock file maintenance feature to keep transitive dependencies up
   // to date.
   lockFileMaintenance: {


### PR DESCRIPTION
**Description:**

Set renovate `minimumReleaseAge` to delay installing Ruby versions that are too new for Netlify, and for better security.

**Related Issues:**

Fixes #509 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Update documentation if applicable.
