### PR TITLE
chore: add jekyll-build target.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,13 +15,13 @@
 [build]
 base = "."
 publish = "_site/"  # relative to `base` directory
-command = "bundle exec jekyll build"
+command = "make jekyll-build"
 
 [context.dev]
-  command = "bundle exec jekyll build --drafts --future --unpublished"
+  command = "make jekyll-build"
 
 [context.deploy-preview]
-  command = "bundle exec jekyll build --drafts --future"
+  command = "make jekyll-build"
   # Skip deploy previews for Renovate PRs (branches starting with "renovate/")
   ignore = "sh -c '[ \"${HEAD#renovate/}\" != \"$HEAD\" ]'"
 


### PR DESCRIPTION
**Description:**

It seems like Netlify doesn't install the Gemfile build dependencies automatically anymore. Instead, have it run `make` which will install the required dependencies.

**Related Issues:**

n/a

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Update documentation if applicable.
