### PR TITLE
fix: set max height for profile image

### DIFF
--- a/content/_sass/plain.scss
+++ b/content/_sass/plain.scss
@@ -220,8 +220,8 @@ main {
 
     img {
       max-width: calc(#{vars.$left-width} - 50px);
-      min-height: 100px;
       max-height: 20vh;
+      min-height: 100px;
     }
 
     .about-header {
@@ -419,6 +419,7 @@ footer {
 
         img {
           max-height: 40px;
+          min-height: auto;
         }
 
         h2 {


### PR DESCRIPTION
**Description:**

Set a max height for the profile image in the left menu. This should limit the height of the sidebar so that it doesn't cut off the bottom of the screen.

**Related Issues:**

Fixes #536 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [x] Update documentation if applicable.
