### PR TITLE
chore: relax validation of HTML IDs [skip netlify]

### DIFF
--- a/.htmlvalidate.mjs
+++ b/.htmlvalidate.mjs
@@ -24,6 +24,12 @@ export default defineConfig({
     // https://html.spec.whatwg.org/multipage/syntax.html#the-doctype
     "doctype-style": "off",
 
+    // Only validate using the definition from the HTML standard.
+    // NOTE: IDs starting with numbers etc. can require intricate escaping if
+    //       used in a selector. However, Kramdown gives little control over how
+    //       it generates IDs or things like footer citations.
+    "valid-id": ["error", { relaxed: true }],
+
     // TODO(#320): Don't use inline style in blog posts.
     "no-inline-style": "off",
 
@@ -31,7 +37,6 @@ export default defineConfig({
     "long-title": "off",
     "no-trailing-whitespace": "off",
     "unique-landmark": "off",
-    "valid-id": "off",
     "void-style": "off",
     "wcag/h30": "off",
     "wcag/h37": "off",


### PR DESCRIPTION
**Description:**

Enable validation of HTML IDs but in relaxed mode that adheres to the HTML5 spec only in the strictest sense.

**Related Issues:**

Fixes #575

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Update documentation if applicable.
