### PR TITLE
ci(html-validate): use _config.mock.yml in base branch

### DIFF
--- a/.github/workflows/workflow_call.html-validate.yml
+++ b/.github/workflows/workflow_call.html-validate.yml
@@ -68,8 +68,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # NOTE: mock the site.time to ensure consistent diff output.
-          # TODO(#641): Uncomment after merging _config.mock.yml
-          # JEKYLL_BUILD_OPTIONS: --drafts --future --unpublished --config=_config.yml,_config.mock.yml
+          JEKYLL_BUILD_OPTIONS: --drafts --future --unpublished --config=_config.yml,_config.mock.yml
         working-directory: "base"
         run: make build
 


### PR DESCRIPTION
**Description:**

Uncomment use of `_config.mock.yml` for the base branch.

**Related Issues:**

- Resolves #641 

**Checklist:**

- [x] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [x] Add a reference to a related issue in the repository.
- [x] Add a description of the changes proposed in the pull request.
- [ ] Update documentation if applicable.
